### PR TITLE
Add support for Intercom('trackEvent')

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,9 @@ This service exposes some of the [Intercom available API](https://docs.intercom.
     this.get('intercom').showNewMessage('My text');
   this.get('intercom').showNewMessage();
   ```
+  
+* `Intercom('trackEvent')`
+
+  ```javascript
+    this.get('intercom').trackEvent('event-name', { meta: data });
+  ```

--- a/app/services/intercom.js
+++ b/app/services/intercom.js
@@ -33,5 +33,9 @@ export default Ember.Service.extend({
     } else {
       Intercom('showNewMessage');
     }
+  },
+
+  trackEvent(eventName, params) {
+    Intercom('trackEvent', eventName, params);
   }
 });


### PR DESCRIPTION
Continuing the work of @andreicek, this PR adds support for event tracking.

While implementing a user on-boarding, I was faced with issues using url-based condition. Events works better in most cases in single page apps. 

FYI: currently, Intercom('update') is called on every page transition but I was informed by Intercom support that there is a SPA limit of 10 calls per 30 minutes. As a consequence, "last viewed" does not always reflect the last page the user was on. Hence, using events has been reliable for me. 
